### PR TITLE
Fix: Add load_device method to Guider_SheduledCFG

### DIFF
--- a/guiders/SheduledGuider.py
+++ b/guiders/SheduledGuider.py
@@ -39,6 +39,9 @@ class Guider_SheduledCFG: # Removed inheritance from comfy.samplers.CFGGuider
     def get_model_object(self, key):
         return self.inner_model.get_model_object(key)
 
+    def load_device(self):
+        self.inner_model.load_device()
+
     def set_use_negative(self, use_neg: bool):
         self.use_negative_as_unconditional = use_neg
 


### PR DESCRIPTION
The Guider_SheduledCFG class was missing the load_device attribute, which is expected by the latent_preview.prepare_callback function in ComfyUI.

This change adds a load_device method to Guider_SheduledCFG that delegates the call to its inner_model. This resolves the AttributeError and allows the PerpNegScheduledCFGGuider node to function correctly with latent previews.